### PR TITLE
Add disclaimer to allow style reset or normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If you feel that you have a personal project that closely resembles this project
 
 ## General Requirements
 - You may not use any existing SCSS (SASS), LESS, or CSS frameworks.
+  - You may use a style reset, or normalize if you wish.
 - You must use SCSS (SASS) to demonstrate competency with the language.
 
 ## Rune Mastery Loadout Talent Calculator 9000


### PR DESCRIPTION
During an interview a candidate mentioned they didn't use a button element as they didn't want to go through all the hassle that a style reset or normalize.css would do for you, and instead used an anchor element as they're already fairly consistent between browsers.

I think it's reasonable to allow the usage of a reset, or normalize.css while still forbidding the use of prepackaged styles like bootstrap